### PR TITLE
Use jitsi stun servers instead of Google.

### DIFF
--- a/group_vars/all/clear.yml
+++ b/group_vars/all/clear.yml
@@ -128,9 +128,7 @@ jitsi_config:
     enabled: true
     # useStunTurn: true
     stunServers:
-      - urls: 'stun:stun.l.google.com:19302'
-      - urls: 'stun:stun1.l.google.com:19302'
-      - urls: 'stun:stun2.l.google.com:19302'
+      - urls: 'stun:meet-jit-si-turnrelay.jitsi.net:443'
     # iceTransportPolicy: 'all'
     preferH264: true
     # disableH264: false


### PR DESCRIPTION
This matches upstream config as set in https://github.com/jitsi/jitsi-meet/pull/5433/
Announced in https://mastodon.nl/web/statuses/103924768952341004

This fixes https://github.com/vc4all/jitsi-hacks/issues/4